### PR TITLE
Fix 0.5.x Compatibility

### DIFF
--- a/sphinxcontrib/exceltable.py
+++ b/sphinxcontrib/exceltable.py
@@ -566,7 +566,7 @@ def setup(app):
   """
 
   # Sphinx 0.5 support
-  if '5' in sphinx.__version__.split('.'):
+  if '0.5' in '.'.join(sphinx.__version__.split('.')[:-1]): # 0.5.x (Ignore minor release)
     app.add_directive('exceltable', ExcelTableDirective, 0, (0, 0, 0))
   else:
     app.add_directive('exceltable', ExcelTableDirective)


### PR DESCRIPTION
Previously, extension would apply 0.5.x compatibility check on versions 5.x.x causing an exception.