### PR TITLE
Create 0.2.3 Release to Resolve #2 without Pre-release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sphinxcontrib-exceltable
-version = 0.3.0-dev1
+version = 0.3.0
 author = Juha Mustonen
 author_email = juha.p.mustonen@gmail.com
 description = Support for including Excel spreadsheets into Sphinx documents


### PR DESCRIPTION
Pre-release sphinxcontrib-exceltable 0.3.0.dev1 should not be necessary to resolve #2. Add 0.2.3 Release once version has been thoroughly tested.

Add this PR before #9 in order to fix older functionality before adding the newest functionality.